### PR TITLE
Troubleshoot gradle build errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,12 +43,12 @@ android {
         isCoreLibraryDesugaringEnabled = true
     }
     
-    // Kotlin configuration without explicit toolchain
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs += listOf("-opt-in=kotlin.RequiresOptIn")
     }
 
-    packagingOptions {
+    packaging {
         resources {
             excludes += listOf(
                 "META-INF/NOTICE.md",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     // Project level plugins
-    id("com.android.application") version "7.4.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.0" apply false
-    id("com.google.gms.google-services") version "4.3.15" apply false
+    id("com.android.application") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("com.google.gms.google-services") version "4.4.1" apply false
 }
 
 tasks.register("clean", Delete::class) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Suppress warning about compileSdk 34 with older AGP versions
+android.suppressUnsupportedCompileSdk=34


### PR DESCRIPTION
Update Android Gradle Plugin and dependencies to resolve build failures and compatibility issues.

The previous configuration had an outdated Android Gradle Plugin (AGP) version (7.4.2) which conflicted with `compileSdk = 34` and caused D8 dexing errors with Firebase and Google Play Services dependencies. This PR updates AGP to 8.2.2, along with compatible Kotlin and Google Services plugin versions, addresses deprecated `packagingOptions`, and adds a suppression property for `compileSdk` warnings, ensuring a successful build.

---
<a href="https://cursor.com/background-agent?bcId=bc-0d657bc0-4918-4c17-9a38-0a02c0d81c51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0d657bc0-4918-4c17-9a38-0a02c0d81c51">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>