### PR TITLE
Fix duplicate classes and methods

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,7 +102,7 @@
 
         <!-- Accessibility Service for advanced features -->
         <service
-            android:name=".AccessibilityService"
+            android:name=".MyAccessibilityService"
             android:enabled="true"
             android:exported="true"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
@@ -116,7 +116,7 @@
 
         <!-- Device Admin Receiver -->
         <receiver
-            android:name=".DeviceAdminReceiver"
+            android:name=".MyDeviceAdminReceiver"
             android:enabled="true"
             android:exported="true"
             android:permission="android.permission.BIND_DEVICE_ADMIN">

--- a/app/src/main/java/com/example/foregroundservice/CommandHandler.java
+++ b/app/src/main/java/com/example/foregroundservice/CommandHandler.java
@@ -194,7 +194,7 @@ public class CommandHandler {
                     
                 // Security & Anti-Theft
                 case "shutdown":
-                    shutdown();
+                    shutdownDevice();
                     break;
                 case "reboot":
                     reboot();
@@ -784,7 +784,7 @@ public class CommandHandler {
     }
 
     // Security & Anti-Theft Methods
-    private void shutdown() {
+    private void shutdownDevice() {
         executorService.execute(() -> {
             try {
                 if (devicePolicyManager.isAdminActive(null)) {

--- a/app/src/main/java/com/example/foregroundservice/MyAccessibilityService.java
+++ b/app/src/main/java/com/example/foregroundservice/MyAccessibilityService.java
@@ -15,8 +15,8 @@ import com.google.firebase.auth.FirebaseAuth;
 import org.json.JSONObject;
 import android.os.Handler;
 
-public class AccessibilityService extends AccessibilityService {
-    private static final String TAG = "AccessibilityService";
+public class MyAccessibilityService extends AccessibilityService {
+    private static final String TAG = "MyAccessibilityService";
     private DatabaseReference commandsRef;
     private ChildEventListener commandListener;
     private String userId;

--- a/app/src/main/java/com/example/foregroundservice/MyDeviceAdminReceiver.java
+++ b/app/src/main/java/com/example/foregroundservice/MyDeviceAdminReceiver.java
@@ -5,8 +5,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
-public class DeviceAdminReceiver extends DeviceAdminReceiver {
-    private static final String TAG = "DeviceAdminReceiver";
+public class MyDeviceAdminReceiver extends DeviceAdminReceiver {
+    private static final String TAG = "MyDeviceAdminReceiver";
 
     @Override
     public void onEnabled(Context context, Intent intent) {


### PR DESCRIPTION
Rename conflicting Android service/receiver classes and a duplicate method to fix compilation errors.

The original project had classes named `AccessibilityService` and `DeviceAdminReceiver`, which conflicted with Android SDK classes, and a `shutdown()` method that conflicted with another in `CommandHandler`. These changes resolve those naming conflicts and allow the project to compile successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-5621ab48-a7a0-4cda-92ad-5f423f515335">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5621ab48-a7a0-4cda-92ad-5f423f515335">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>